### PR TITLE
added modal-header and modal-body style changes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -115,6 +115,15 @@
   z-index: 3;
 }
 
+.modal-body {
+  max-height: 600px; /* Even if it's too high to fit in the screen, you won't have to scroll down long to get to the footer */
+}
+
+.modal-header,
+.modal-footer {
+  background-color: rgb(247,247,247);
+}
+
 .page-card img {
   object-fit: contain;
   height: 200px;


### PR DESCRIPTION
Just added code to style.css to make it so you don't have to scroll past all the search results to get to the footer.  And the modal-header isn't transparent and you can't see the search results through it when you scroll down.
```
.modal-body {
  max-height: 600px; /* Even if it's too high to fit in the screen, you won't have to scroll down long to get to the footer */
}

.modal-header,
.modal-footer {
  background-color: rgb(247,247,247);
}
```