### PR TITLE
38 deploy arrangement of cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -86,8 +86,8 @@
   flex: 1 0 0%;
 }
 
-#space .card {
-  /* min-width: 30%; */
+.deploy-card-deck .card {
+  min-width: 200px;
 }
 
 .card-deck {

--- a/assets/js/deploy-script.js
+++ b/assets/js/deploy-script.js
@@ -17,7 +17,8 @@ window.onload = function() {
     console.log(pageData.title);
   }
 
-  if (pageData.heading) {
+  if (!isBlankOrHidden(pageData.heading)) {
+    headingArea.addClass("d-flex").removeClass("d-none");
     headingArea.append(displayHeading(pageData.heading));
   }
 
@@ -28,6 +29,17 @@ window.onload = function() {
   }
 
 }
+
+function isBlankOrHidden(cardData) {
+  if (!cardData.show) {
+    return true
+  } else {
+    if (!cardData.title && !cardData.src) {
+      return true
+    } else {return false}
+  }
+}
+
 
 function gotoHomePage() {
   // include some kind of saving function, just in case?

--- a/assets/js/editor-script.js
+++ b/assets/js/editor-script.js
@@ -183,6 +183,7 @@ function displayHeading(cardData) {
   if (!cardData.show) {
     card.addClass("d-none");
     card.removeClass("d-flex");
+    headingArea.addClass("small");
   }
 
   return card
@@ -192,7 +193,7 @@ function headingButton(show=true) {
   // This button can be clicked to add a heading.  It removes class="d-none" from the heading already in the html, and updates pageData.heading.show.  Then it sets its own display to none.
   // The heading card will have a delete button to do the reverse.
 
-  const button = $("<button>").text("Add heading or question!").addClass("btn btn-warning btn-lg").click(showHeading).attr("id","heading-btn");
+  const button = $("<button>").text("Add heading or question!").addClass("btn btn-warning btn-lg w-100").click(showHeading).attr("id","heading-btn");
   if (show) {
     button.addClass("d-none");
   }

--- a/deploy.html
+++ b/deploy.html
@@ -18,7 +18,7 @@
         <a class="btn btn btn-outline-primary" href="./homepage.html"><i class="btn-symbol" role="icon">&#x1F519;</i></a>
       </div>
       <div class="col d-flex flex-column">
-        <div id="heading-area">
+        <div id="heading-area" class="d-none">
         </div>
         <div id="space" class="card-deck deploy-card-deck d-flex flex-wrap flex-row flex-grow-1">
 

--- a/deploy.html
+++ b/deploy.html
@@ -20,7 +20,7 @@
       <div class="col d-flex flex-column">
         <div id="heading-area">
         </div>
-        <div id="space" class="card-deck d-flex flex-row flex-grow-1">
+        <div id="space" class="card-deck deploy-card-deck d-flex flex-wrap flex-row flex-grow-1">
 
         </div>
 


### PR DESCRIPTION
In deploy.html, all the cards are just in one long row.

Since deploy has a much simpler layout, just need to add `min-width: 200px` or `min-width: 30%` to the cards, and add class flex-wrap to the card-deck.

Also the header always shows even when it's not supposed to. Which wasn't a big deal when it was just a small gray line, but after giving it a set height to be able to see the image, it's really obvious.

There's just one or two things to add to fix that.